### PR TITLE
Fix version of lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "requires": {
         "@babel/types": "^7.4.4",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       }
@@ -114,7 +114,7 @@
         "@babel/types": "^7.4.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "debug": {
@@ -141,7 +141,7 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -172,7 +172,7 @@
       "requires": {
         "@sinonjs/commons": "^1.0.2",
         "array-from": "^2.1.1",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@sinonjs/text-encoding": {
@@ -587,7 +587,7 @@
         "didyoumean": "^1.2.1",
         "inquirer": "^6.2.1",
         "json-fixer": "^1.3.1-0",
-        "lodash": "^4.11.2",
+        "lodash": "^4.11.13",
         "pify": "^4.0.1",
         "request": "^2.72.0",
         "yargs": "^13.1.0"
@@ -2274,7 +2274,7 @@
         "js-yaml": "^3.13.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
@@ -2467,7 +2467,7 @@
         "find-root": "^1.1.0",
         "has": "^1.0.1",
         "interpret": "^1.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.13",
         "node-libs-browser": "^1.0.0 || ^2.0.0",
         "resolve": "^1.10.0",
         "semver": "^5.3.0"
@@ -2515,7 +2515,7 @@
         "eslint-import-resolver-node": "^0.3.2",
         "eslint-module-utils": "^2.4.0",
         "has": "^1.0.3",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "minimatch": "^3.0.4",
         "read-pkg-up": "^2.0.0",
         "resolve": "^1.10.0"
@@ -4273,7 +4273,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
@@ -4969,9 +4969,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -7354,7 +7354,7 @@
       "dev": true,
       "requires": {
         "ajv": "^6.9.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       },
@@ -7831,7 +7831,7 @@
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.13",
         "postinstall-build": "^5.0.1"
       }
     },
@@ -8466,7 +8466,7 @@
       "dev": true,
       "requires": {
         "flat": "^4.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "yargs": "^12.0.5"
       },
       "dependencies": {


### PR DESCRIPTION
CVE-2019-10744
Vulnerable versions: < 4.17.13
Patched version: 4.17.13

Affected versions of lodash are vulnerable to Prototype Pollution.
The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.